### PR TITLE
fix: extract_gender returns 'female' when no matches found for name

### DIFF
--- a/gender_extractor/extractor.py
+++ b/gender_extractor/extractor.py
@@ -97,13 +97,15 @@ class GenderExtractor:
             m_count = sum(m_counts) + 1e-6
             f_count = sum(f_counts) + 1e-6
 
-        if f_count/m_count > 0.9:
+        if m_count == 1e-6 and f_count == 1e-6:
+            return "ambiguous"
+        elif f_count / m_count > 0.9:
             return "female"
-        elif f_count/m_count > 0.6:
+        elif f_count / m_count > 0.6:
             return "mostly female"
-        elif m_count/f_count > 0.9:
+        elif m_count / f_count > 0.9:
             return "male"
-        elif m_count/f_count > 0.6:
+        elif m_count / f_count > 0.6:
             return "mostly male"
         else:
             return "ambiguous"


### PR DESCRIPTION
extract_gender function is always returns 'female' even for cases, when no name matches found (m_count = 0, f_count = 0).